### PR TITLE
Update pybind11

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -12,7 +12,7 @@ source:
     sha256: {{ sha256 }}
 
 build:
-  number: 0
+  number: 1
 
 requirements:
   build:
@@ -25,7 +25,7 @@ requirements:
   run:
     - xtl >=0.2.8,<0.13
     - xtensor >=0.12.0,<0.13
-    - pybind11 >=2.1.0,<2.2
+    - pybind11 >=2.1.0,<2.3
     - numpy
 
 test:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -23,7 +23,7 @@ requirements:
     - pybind11
     - numpy
   run:
-    - xtl >=0.2.8,<0.13
+    - xtl >=0.2.8,<0.3
     - xtensor >=0.12.0,<0.13
     - pybind11 >=2.1.0,<2.3
     - numpy


### PR DESCRIPTION
I want that sweet, sweet support for [`py::call_guard`](http://pybind11.readthedocs.io/en/stable/advanced/functions.html#call-guard).